### PR TITLE
リリースワークフローを整理する

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,4 +1,4 @@
-name: Release Windows Installer
+name: Release Windows Installers
 
 on:
   push:
@@ -86,13 +86,18 @@ jobs:
         if: steps.version.outputs.changed == 'true' && steps.existing_release.outputs.exists == 'false'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Windows Rust targets
+        if: steps.version.outputs.changed == 'true' && steps.existing_release.outputs.exists == 'false'
+        run: rustup target add x86_64-pc-windows-msvc aarch64-pc-windows-msvc
+
       - name: Cache Rust build
         if: steps.version.outputs.changed == 'true' && steps.existing_release.outputs.exists == 'false'
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
 
-      - name: Build installer and create release
+      - name: Build x64 installer and create release
+        id: build_x64
         if: steps.version.outputs.changed == 'true' && steps.existing_release.outputs.exists == 'false'
         uses: tauri-apps/tauri-action@v0
         env:
@@ -104,4 +109,14 @@ jobs:
           releaseDraft: false
           prerelease: false
           uploadUpdaterJson: false
-          args: --bundles nsis
+          args: --target x86_64-pc-windows-msvc --bundles nsis
+
+      - name: Build ARM64 installer and upload to release
+        if: steps.version.outputs.changed == 'true' && steps.existing_release.outputs.exists == 'false'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: ${{ steps.build_x64.outputs.releaseId }}
+          uploadUpdaterJson: false
+          args: --target aarch64-pc-windows-msvc --bundles nsis

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,14 @@
 - ARM64 環境での再現確認は、x64 エミュレーションか ARM64 ネイティブかを必ず分けて見る。
 - リリース前にローカルでリリースビルドを作る場合は、対象アーキテクチャを明示する。GitHub Actions のリリース生成条件とも整合させる。
 
+### リリースワークフロー
+- リリースするかどうか、またバージョンを上げるかどうかが明示されていない場合は、作業前または push 前にユーザへ確認する。
+- バージョンを上げる場合は `package.json`、`package-lock.json`、`src-tauri/Cargo.toml`、`src-tauri/Cargo.lock`、`src-tauri/tauri.conf.json` を同じ version に揃える。
+- バージョン更新を含む変更を commit してから push する。バージョン更新なしの push では GitHub Release を作らない。
+- Windows installer のビルドと GitHub Release 作成は GitHub Actions の責務とする。ローカルでリリースビルドを作るのは確認目的に留め、成果物を手動で release に添付しない。
+- `src-tauri/tauri.conf.json` の version が main への push で変わったとき、Actions が `v<version>` の release を作り、x64 と ARM64 の Windows installer を添付する。
+- Actions 側で同じ release を複数 job / step から新規作成しない。最初に作成した release ID に後続アーキテクチャの成果物をアップロードする。
+
 ## 今後も維持したい方向性
 - 「静かで、少ない UI で、しかし本文保護だけは強い」こと。
 - データ所有権はユーザー側、安心感はアプリ側、という役割分担を崩さないこと。
@@ -94,4 +102,4 @@
 
 ## Push時のルール
 
-Push前にバージョンを上げるかどうかユーザに聞くこと。バージョンを上げる場合はリリースビルドを作成すること。
+Push前にバージョンを上げるかどうかユーザに聞くこと。バージョンを上げる場合は、バージョン更新を commit してから push し、リリースビルドと GitHub Release 作成は Actions に任せること。

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "tauri": "tauri",
-    "build:tauri:x64": "tauri build --target x86_64-pc-windows-msvc"
+    "build:tauri:x64": "tauri build --target x86_64-pc-windows-msvc",
+    "build:tauri:arm64": "tauri build --target aarch64-pc-windows-msvc"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",


### PR DESCRIPTION
## Summary
- リリース判断とバージョン更新手順を AGENTS.md に明文化
- Windows release workflow を x64 と ARM64 installer 対応に更新
- 同一 GitHub Release の作成競合を避けるため、x64 作成後に ARM64 を releaseId へアップロード

## Version
- 今回はバージョンを上げない